### PR TITLE
Fix multi-monitor popup anchoring, tidy internals, add name-matching tests

### DIFF
--- a/src/audio_manager.py
+++ b/src/audio_manager.py
@@ -284,27 +284,11 @@ class AudioManager:
                 policy.SetDefaultEndpoint(device_id, role)
             return True
         except Exception as exc:
+            # There is deliberately no fallback here. The previous one shelled
+            # out to Set-AudioDevice from the third-party AudioDeviceCmdlets
+            # module, which is not a dependency and is not installed by
+            # default, so it spawned a PowerShell process only to fail.
             log.error("Failed to set default device %s: %s", device_id, exc)
-            return self._fallback_set_default(device_id)
-
-    def _fallback_set_default(self, device_id: str) -> bool:
-        """Fallback: use AudioDeviceCmdlets via PowerShell."""
-        import subprocess
-        try:
-            result = subprocess.run(
-                [
-                    "powershell",
-                    "-Command",
-                    f'Set-AudioDevice -ID "{device_id}"',
-                ],
-                capture_output=True,
-                text=True,
-                creationflags=subprocess.CREATE_NO_WINDOW,
-                timeout=5,
-            )
-            return result.returncode == 0
-        except Exception as exc:
-            log.error("Fallback device switch failed: %s", exc)
             return False
 
     def register_change_callback(self, on_change: Callable[[], None]) -> None:

--- a/src/icons.py
+++ b/src/icons.py
@@ -40,6 +40,8 @@ _KEYWORD_MAP: list[tuple[list[str], str]] = [
     (["earbud", "in-ear", "inear"], "earbuds"),
     (["bluetooth", "airpods", "buds", "galaxy buds"], "bluetooth"),
     (["monitor", "hdmi", "displayport", "display"], "monitor"),
+    # After the display entry, so an HDMI-connected TV still reads as a monitor
+    (["tv", "television"], "tv"),
     (["webcam", "camera"], "camera"),
     (["soundbar"], "soundbar"),
     (["dac", "audio interface", "interface"], "mixer"),

--- a/src/ui.py
+++ b/src/ui.py
@@ -865,14 +865,14 @@ class DeviceDropdown(QWidget):
         # BT connect: disconnected BT favourite → keep dropdown open
         if not device.is_connected and device.is_bluetooth:
             self._bt_busy = True
-            self._set_row_status(device.id, "Connecting\u2026")
+            self.set_row_status(device.id, "Connecting\u2026")
             self.bt_connect_requested.emit(device)
             return
 
         # BT disconnect: only when it's already the active (default) device
         if device.is_bluetooth and device.is_connected and device.is_default:
             self._bt_busy = True
-            self._set_row_status(device.id, "Disconnecting\u2026")
+            self.set_row_status(device.id, "Disconnecting\u2026")
             self.bt_disconnect_requested.emit(device)
             return
 
@@ -880,8 +880,12 @@ class DeviceDropdown(QWidget):
         self.device_selected.emit(device)
         self._fade_out_and_close()
 
-    def _set_row_status(self, device_id: str, text: str) -> None:
-        """Update the name label on a device row (e.g. 'Connecting…')."""
+    def set_row_status(self, device_id: str, text: str) -> None:
+        """Update the name label on a device row (e.g. 'Connecting…').
+
+        Public because AudioFlipWidget drives it while a Bluetooth
+        operation runs on a background thread.
+        """
         row = self._rows_by_device_id.get(device_id)
         if row:
             row.set_name_text(text)
@@ -894,13 +898,17 @@ class DeviceDropdown(QWidget):
         """
         self._bt_busy = False
         if success:
-            self._repopulate()
+            self.repopulate()
         else:
             label = "Connection failed" if action == "connect" else "Disconnect failed"
-            self._set_row_status(device_id, label)
+            self.set_row_status(device_id, label)
 
-    def _repopulate(self) -> None:
-        """Re-populate the dropdown in-place with fresh device data."""
+    def repopulate(self) -> None:
+        """Re-populate the dropdown in-place with fresh device data.
+
+        Public because AudioFlipWidget refreshes the open dropdown after a
+        favourite toggle or a Bluetooth state change.
+        """
         self.populate_and_show(
             self.pos(),
             self._last_show_mode,
@@ -984,6 +992,11 @@ class _BodyWidget(QWidget):
     @property
     def volume_active(self) -> bool:
         return self._vol_opacity > 0.01
+
+    @property
+    def volume_level(self) -> float:
+        """Last level shown, used to avoid API rounding jitter while scrolling."""
+        return self._vol_level
 
     def _vol_start_fade(self) -> None:
         self._vol_fade_timer.start()
@@ -1871,7 +1884,7 @@ class AudioFlipWidget(QWidget):
         # Update dropdown row status
         if self._dropdown and self._dropdown.isVisible():
             if action == "connect" and success:
-                self._dropdown._set_row_status(device_id or "", "Connected \u2014 switching\u2026")
+                self._dropdown.set_row_status(device_id or "", "Connected \u2014 switching\u2026")
             elif not success:
                 # Show failure on dropdown, it will auto-close after 2s
                 self._dropdown.show_bt_result(device_id or "", False, action)
@@ -1946,7 +1959,7 @@ class AudioFlipWidget(QWidget):
                 # Don't show failure — the 4s retry may still succeed
                 log.info("1.5s switch attempt inconclusive for '%s', 4s retry pending", dev_name)
                 if self._dropdown and self._dropdown.isVisible():
-                    self._dropdown._set_row_status(dropdown_device_id or "", "Switching\u2026")
+                    self._dropdown.set_row_status(dropdown_device_id or "", "Switching\u2026")
 
         self._refresh_display()
 
@@ -1987,7 +2000,7 @@ class AudioFlipWidget(QWidget):
 
         self._refresh_display()
         if self._dropdown and self._dropdown.isVisible():
-            self._dropdown._repopulate()
+            self._dropdown.repopulate()
 
     def _find_bt_device_by_name(self, name: str) -> AudioDevice | None:
         """Find an active BT audio device whose name matches the given name."""
@@ -2019,7 +2032,7 @@ class AudioFlipWidget(QWidget):
         )
         # Repopulate in-place — avoids close/reopen flicker and click-through
         if hasattr(self, "_dropdown") and self._dropdown.isVisible():
-            self._dropdown._repopulate()
+            self._dropdown.repopulate()
 
     def _on_dropdown_closed(self) -> None:
         """Record when the dropdown closes so we can suppress immediate reopen."""
@@ -2038,7 +2051,7 @@ class AudioFlipWidget(QWidget):
 
         # Use cached level if overlay is active to avoid API rounding jitter
         if self._body.volume_active:
-            current = self._body._vol_level
+            current = self._body.volume_level
         else:
             current = self._audio_mgr.get_default_volume(flow)
             if current is None:

--- a/src/ui.py
+++ b/src/ui.py
@@ -384,6 +384,21 @@ def _rounded_mask(width: int, height: int, radius: int) -> QBitmap:
     return bmp
 
 
+def _screen_area_at(point: QPoint) -> QRect:
+    """Return the available geometry of the screen containing *point*.
+
+    Popups must be laid out against the screen they will actually appear on.
+    Using the primary screen's geometry sends the grow-up/grow-down decision
+    and the horizontal clamp against the wrong rectangle whenever the widget
+    lives on a secondary monitor.
+
+    availableGeometry (not geometry) is right here: unlike the widget itself,
+    popups should not open underneath the taskbar.
+    """
+    screen = QApplication.screenAt(point) or QApplication.primaryScreen()
+    return screen.availableGeometry() if screen is not None else QRect()
+
+
 def _t(config_mgr: ConfigManager) -> dict[str, str]:
     """Return the active theme palette dict."""
     return _THEMES.get(config_mgr.config.theme, _THEMES["dark"])
@@ -725,7 +740,7 @@ class DeviceDropdown(QWidget):
         if show_mode in ("input", "both"):
             row_count += len(inputs) + 1
         est_height = min(row_count * 38 + 50, 420)
-        screen_geo = QApplication.primaryScreen().availableGeometry()
+        screen_geo = _screen_area_at(anchor)
         if reposition:
             grows_up = (anchor.y() + est_height) > screen_geo.bottom()
             # When grows_up: favourites at bottom (closer to widget) = closer to cursor
@@ -1570,11 +1585,17 @@ class AudioFlipWidget(QWidget):
         QTimer.singleShot(0, self._ensure_on_screen)
 
     def _move_to_screen(self) -> None:
-        """Move the widget to the centre of the current primary screen."""
-        primary = QApplication.primaryScreen()
-        if primary is None:
+        """Move the widget to the centre of the screen under the cursor.
+
+        The README calls this 'reposition widget to the active monitor', but
+        it used to centre on the primary screen regardless. Going by the
+        cursor makes it do what it says, and makes it useful from the tray
+        menu: the widget lands on the monitor you invoked it from.
+        """
+        screen = QApplication.screenAt(QCursor.pos()) or QApplication.primaryScreen()
+        if screen is None:
             return
-        geo = primary.availableGeometry()
+        geo = screen.availableGeometry()
         x = geo.x() + (geo.width() - self.width()) // 2
         y = geo.y() + (geo.height() - self.height()) // 2
         self.move(x, y)
@@ -1596,7 +1617,7 @@ class AudioFlipWidget(QWidget):
         dialog.pair_succeeded.connect(self._on_bt_scan_pair_succeeded)
 
         # Position: same logic as dropdown / context menu
-        screen_geo = QApplication.primaryScreen().availableGeometry()
+        screen_geo = _screen_area_at(self.frameGeometry().center())
         dlg_size = dialog.sizeHint()
         anchor_below = self.mapToGlobal(QPoint(0, self.height() + 4))
         anchor_above = self.mapToGlobal(QPoint(0, -dlg_size.height() - 4))
@@ -2181,7 +2202,7 @@ class AudioFlipWidget(QWidget):
                 submenu.installEventFilter(self)
 
         # Position above or below the widget, like the dropdown
-        screen_geo = QApplication.primaryScreen().availableGeometry()
+        screen_geo = _screen_area_at(self.frameGeometry().center())
         menu_size = self._ctx_menu.sizeHint()
         anchor_below = self.mapToGlobal(QPoint(0, self.height() + 4))
         anchor_above = self.mapToGlobal(QPoint(0, -menu_size.height() - 4))

--- a/tests/test_name_matching.py
+++ b/tests/test_name_matching.py
@@ -1,0 +1,84 @@
+"""Tests for Bluetooth endpoint name matching and icon keyword matching.
+
+Dependency-free: run with `python tests/test_name_matching.py`.
+
+These are the functions behind BT favourite reconciliation - when a device
+reconnects with a new endpoint ID, the only thing tying the old favourite to
+the new endpoint is its name - so getting them wrong silently orphans a
+favourite and its icon override.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from src.icons import match_icon_for_name  # noqa: E402
+from src.ui import _bt_name_core, _bt_names_match  # noqa: E402
+
+
+def test_core_extracts_parenthesised_name() -> None:
+    assert _bt_name_core("Headphones (Buds Pro 2)") == "buds pro 2"
+    assert _bt_name_core("Earphones (Buds Pro 2)") == "buds pro 2"
+
+
+def test_core_uses_last_parentheses() -> None:
+    # Windows nests these: "Audio out (headphones!) (High Definition Audio Device)"
+    assert _bt_name_core(
+        "Audio out (headphones!) (High Definition Audio Device)"
+    ) == "high definition audio device"
+
+
+def test_core_falls_back_to_whole_name() -> None:
+    assert _bt_name_core("Speakers") == "speakers"
+    assert _bt_name_core("  Speakers  ") == "speakers"
+
+
+def test_core_handles_unbalanced_parentheses() -> None:
+    assert _bt_name_core("Headphones Buds Pro 2)") == "headphones buds pro 2)"
+
+
+def test_same_device_different_endpoint_roles_match() -> None:
+    # The case reconciliation exists for: one BT device, two endpoint names
+    assert _bt_names_match("Headphones (Buds Pro 2)", "Earphones (Buds Pro 2)")
+
+
+def test_different_devices_do_not_match() -> None:
+    assert not _bt_names_match("Headphones (Buds Pro 2)", "Headphones (WH-1000XM4)")
+
+
+def test_empty_names_do_not_match() -> None:
+    # Guards against every unnamed device matching every other one
+    assert not _bt_names_match("", "")
+    assert not _bt_names_match("()", "()")
+
+
+def test_icon_keyword_matching() -> None:
+    assert match_icon_for_name("Headphones (Buds Pro 2)") == "headphones"
+    assert match_icon_for_name("Realtek High Definition Audio") == "speaker"
+    assert match_icon_for_name("Samsung TV") == "tv"
+    assert match_icon_for_name("USB Audio Device") == "usb"
+
+
+def test_icon_falls_back_for_unknown_names() -> None:
+    assert match_icon_for_name("Zzzz Unknown Thing") == "audio"
+
+
+def test_icon_matching_is_case_insensitive() -> None:
+    assert match_icon_for_name("HEADPHONES") == "headphones"
+    assert match_icon_for_name("headphones") == "headphones"
+
+
+if __name__ == "__main__":
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if not name.startswith("test_") or not callable(fn):
+            continue
+        try:
+            fn()
+            print(f"  PASS  {name}")
+        except AssertionError as exc:
+            failures += 1
+            print(f"  FAIL  {name}  {exc}")
+    print(f"\n{'FAILED' if failures else 'All passed'} ({failures} failure(s))")
+    sys.exit(1 if failures else 0)


### PR DESCRIPTION
Follow-up to #3: the two multi-monitor bugs from the review that were still outstanding, plus the cleanup items.

## Multi-monitor fixes

**Popups were laid out against the primary screen.** The dropdown's grow-up/grow-down decision and horizontal clamp, the context menu, and the Bluetooth scan dialog all used `QApplication.primaryScreen()`. With the widget on a secondary monitor, every one of those calculations ran against the wrong rectangle - so a popup could choose the wrong grow direction or clamp to an edge nowhere near it. `_screen_area_at()` now resolves the screen containing the anchor point.

It uses `availableGeometry` rather than `geometry`, which is the opposite of what the widget itself needs: the widget is meant to float over the taskbar, popups are not meant to open underneath it.

**'Move to screen' centred on the primary screen** despite the README describing it as 'reposition widget to the active monitor'. Now uses the screen under the cursor, which also makes it useful from the tray menu - the widget lands on the monitor you invoked it from.

## Cleanup

**Cross-class private access.** `AudioFlipWidget` reached into the dropdown's `_set_row_status()`/`_repopulate()` and the body widget's `_vol_level`. These are legitimate collaborations rather than leaks, so they are now public - `set_row_status`, `repopulate`, and a read-only `volume_level` property - with docstrings recording who drives them and why. `_vol_level` is now confined to `_BodyWidget`.

**Dead fallback removed.** `_fallback_set_default()` shelled out to `Set-AudioDevice` from the third-party AudioDeviceCmdlets module, which is not in `requirements.txt` and is not installed by default (confirmed absent on the dev machine). It spawned a PowerShell process only to fail. A failed switch now reports honestly instead of implying a fallback exists.

## Tests

Adds `tests/test_name_matching.py` covering the Bluetooth endpoint name matching behind favourite reconciliation - the code where a wrong answer silently orphans a favourite and its icon override - plus the icon keyword matcher.

Writing them turned up a real gap: `tv` is in `ICON_TYPES` and selectable by hand, but had no entry in `_KEYWORD_MAP`, so a TV never auto-matched its own icon. Added after the display entry so an HDMI-connected TV still reads as a monitor.

## Testing

Both test files pass. The app starts cleanly from source with no errors.

Two caveats worth stating plainly:

- the multi-monitor behaviour **cannot be verified on this machine** - it has a single display, so every point resolves to the same screen. The logic is correct by construction and the fallback path is exercised, but the real test needs a second monitor
- the renamed dropdown methods are only exercised during Bluetooth operations and dropdown interaction, which the startup smoke test does not reach. Worth a manual pass: open the dropdown, toggle a favourite, connect/disconnect a BT device

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mAyGLPdG6hLauG7teRbpD
