### PR TITLE
Fix PowerShell BT fallback and add crash diagnostics

### DIFF
--- a/src/bluetooth.py
+++ b/src/bluetooth.py
@@ -616,6 +616,61 @@ def _win32_disconnect(device_name: str) -> bool:
 # ---------------------------------------------------------------------------
 # PowerShell PnP fallback
 # ---------------------------------------------------------------------------
+def _ps_single_quote(value: str) -> str:
+    """Quote a value for a PowerShell single-quoted string literal."""
+    return "'" + str(value).replace("'", "''") + "'"
+
+
+def _run_powershell(script: str, timeout: int = 15) -> "subprocess.CompletedProcess | None":
+    """Run a PowerShell snippet, returning None if it could not be launched.
+
+    Uses an argument list rather than shell=True. The old form built a single
+    command string and pushed it through cmd.exe, which does not process
+    backslash escapes, so the intended '-Confirm:$false' reached PowerShell
+    with a stray backslash and was rejected as a string where a switch was
+    required. That made the PnP fallback fail every single time.
+
+    CREATE_NO_WINDOW stops a console window flashing over the screen on every
+    Bluetooth fallback attempt.
+    """
+    try:
+        return subprocess.run(
+            ["powershell", "-NoProfile", "-NonInteractive", "-Command", script],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            creationflags=subprocess.CREATE_NO_WINDOW,
+        )
+    except Exception as exc:
+        log.debug("PowerShell invocation failed: %s", exc)
+        return None
+
+
+def _pnp_set_enabled(instance_id: str, enable: bool) -> bool:
+    """Enable or disable a PnP device via PowerShell."""
+    verb = "Enable" if enable else "Disable"
+    result = _run_powershell(
+        f"{verb}-PnpDevice -InstanceId {_ps_single_quote(instance_id)} "
+        f"-Confirm:$false -ErrorAction Stop"
+    )
+    if result is None:
+        log.warning("PowerShell: %s-PnpDevice could not be launched", verb)
+        return False
+    if result.returncode == 0:
+        log.info("PowerShell: %s-PnpDevice succeeded for %s", verb, instance_id)
+        return True
+
+    stderr = (result.stderr or "").strip()
+    if "denied" in stderr.lower() or "administrator" in stderr.lower():
+        log.warning(
+            "PowerShell: %s-PnpDevice needs admin privileges "
+            "(audioflip must run elevated for this fallback)", verb,
+        )
+    else:
+        log.warning("PowerShell: %s-PnpDevice failed: %s", verb, stderr)
+    return False
+
+
 def _find_bt_pnp_instance_id(device_name: str) -> str | None:
     """Find the PnP instance ID for a Bluetooth device by name.
 
@@ -623,21 +678,17 @@ def _find_bt_pnp_instance_id(device_name: str) -> str | None:
     friendly name (case-insensitive substring).
     """
     name_lower = device_name.lower()
-    cmd = (
-        'powershell -NoProfile -Command "'
+    result = _run_powershell(
         "Get-PnpDevice -Class Bluetooth -ErrorAction SilentlyContinue "
         "| Select-Object InstanceId, FriendlyName, Status "
-        '| ConvertTo-Json -Compress"'
+        "| ConvertTo-Json -Compress",
+        timeout=10,
     )
-    try:
-        result = subprocess.run(
-            cmd, shell=True, capture_output=True, text=True, timeout=10,
+    if result is None or result.returncode != 0:
+        log.debug(
+            "Get-PnpDevice failed: %s",
+            result.stderr.strip() if result else "could not launch PowerShell",
         )
-        if result.returncode != 0:
-            log.debug("Get-PnpDevice failed: %s", result.stderr.strip())
-            return None
-    except Exception as exc:
-        log.debug("Get-PnpDevice exception: %s", exc)
         return None
 
     try:
@@ -667,52 +718,12 @@ def _find_bt_pnp_instance_id(device_name: str) -> str | None:
 
 def _powershell_enable(instance_id: str) -> bool:
     """Enable a PnP device (reconnect) via PowerShell."""
-    cmd = (
-        f'powershell -NoProfile -Command "'
-        f"Enable-PnpDevice -InstanceId '{instance_id}' -Confirm:\\$false"
-        f' -ErrorAction Stop"'
-    )
-    try:
-        result = subprocess.run(
-            cmd, shell=True, capture_output=True, text=True, timeout=15,
-        )
-        if result.returncode == 0:
-            log.info("PowerShell: Enable-PnpDevice succeeded for %s", instance_id)
-            return True
-        stderr = result.stderr.strip()
-        if "Access" in stderr or "denied" in stderr or "administrator" in stderr.lower():
-            log.warning("PowerShell: Enable-PnpDevice needs admin privileges")
-        else:
-            log.warning("PowerShell: Enable-PnpDevice failed: %s", stderr)
-        return False
-    except Exception as exc:
-        log.warning("PowerShell: Enable-PnpDevice exception: %s", exc)
-        return False
+    return _pnp_set_enabled(instance_id, True)
 
 
 def _powershell_disable(instance_id: str) -> bool:
     """Disable a PnP device (disconnect) via PowerShell."""
-    cmd = (
-        f'powershell -NoProfile -Command "'
-        f"Disable-PnpDevice -InstanceId '{instance_id}' -Confirm:\\$false"
-        f' -ErrorAction Stop"'
-    )
-    try:
-        result = subprocess.run(
-            cmd, shell=True, capture_output=True, text=True, timeout=15,
-        )
-        if result.returncode == 0:
-            log.info("PowerShell: Disable-PnpDevice succeeded for %s", instance_id)
-            return True
-        stderr = result.stderr.strip()
-        if "Access" in stderr or "denied" in stderr or "administrator" in stderr.lower():
-            log.warning("PowerShell: Disable-PnpDevice needs admin privileges")
-        else:
-            log.warning("PowerShell: Disable-PnpDevice failed: %s", stderr)
-        return False
-    except Exception as exc:
-        log.warning("PowerShell: Disable-PnpDevice exception: %s", exc)
-        return False
+    return _pnp_set_enabled(instance_id, False)
 
 
 def _powershell_connect(device_name: str) -> bool:

--- a/src/main.py
+++ b/src/main.py
@@ -6,6 +6,8 @@ starts the PyQt6 event loop.
 
 from __future__ import annotations
 
+import datetime
+import faulthandler
 import os
 import sys
 import logging
@@ -41,12 +43,42 @@ def _setup_logging() -> None:
     logging.getLogger().addHandler(file_handler)
 
 
+_crash_file = None  # module-level so the handle outlives _setup_crash_handler
+
+
+def _setup_crash_handler() -> None:
+    """Write a Python traceback to disk if the process dies in native code.
+
+    The packaged build runs with console=False, so stderr goes nowhere. A
+    native crash - an access violation inside a ctypes or COM call, say -
+    then kills the process silently, leaving only a log that stops
+    mid-sentence. faulthandler dumps the stack of every thread instead,
+    which is the difference between a diagnosable crash and a mystery.
+    """
+    global _crash_file
+    try:
+        log_dir = os.path.join(os.environ.get("APPDATA", "."), "audioflip")
+        os.makedirs(log_dir, exist_ok=True)
+        _crash_file = open(
+            os.path.join(log_dir, "crash.log"), "a", buffering=1, encoding="utf-8",
+        )
+        _crash_file.write(
+            "\n===== session started "
+            + datetime.datetime.now().isoformat(timespec="seconds")
+            + " =====\n"
+        )
+        faulthandler.enable(file=_crash_file, all_threads=True)
+    except Exception:
+        pass  # diagnostics must never stop the app starting
+
+
 log = logging.getLogger(__name__)
 
 
 def main() -> int:
     """Launch the audioflip widget."""
     _setup_logging()
+    _setup_crash_handler()
     log.info("audioflip starting")
 
     app = QApplication(sys.argv)


### PR DESCRIPTION
Two independent fixes, both found while investigating a crash and a failed Bluetooth connect.

## The PnP fallback has never worked

When `BluetoothSetServiceState` fails, the code falls back to `Enable-PnpDevice`/`Disable-PnpDevice`. That fallback has been broken since it was written in March.

It built a single command string and pushed it through `cmd.exe` with `shell=True`:

```
Enable-PnpDevice -InstanceId '...' -Confirm:\$false
```

`cmd.exe` does not process backslash escapes, so PowerShell received `-Confirm:\$false` and rejected it before touching the device:

```
Cannot convert 'System.String' to the type
'System.Management.Automation.SwitchParameter' required by parameter 'Confirm'
```

So every fallback attempt died on argument binding. A failed Win32 connect had no second chance - only the appearance of one. This is a plausible contributor to Bluetooth connect being unreliable, since the recovery path was inert.

Reproduced outside the app, and confirmed fixed: the same call now returns a genuine "no such device" error rather than a type error.

- `shell=True` replaced with an argument list, which sidesteps the quoting problem entirely
- `CREATE_NO_WINDOW` added - these calls were also flashing a console window over the screen on every attempt
- the near-identical enable/disable bodies now share `_pnp_set_enabled()`
- instance IDs go through `_ps_single_quote()` instead of being interpolated raw
- the admin-privileges warning is clearer, since `Enable-PnpDevice` requires elevation and that is the next thing likely to block this path

## Crash diagnostics

The packaged build runs with `console=False`, so stderr goes nowhere. A native crash - an access violation inside a ctypes or COM call - killed the process silently, leaving a log that simply stopped mid-sentence.

That is exactly what happened today: an access violation in `_ctypes.pyd` during a Bluetooth disconnect, recoverable only as a Windows Error Reporting bucket ID with no stack.

`faulthandler` now writes the stack of every thread to `%APPDATA%/audioflip/crash.log`, so the next occurrence names the line.

## Testing

- the fixed PowerShell invocation was verified to bind correctly, and the instance-ID lookup still resolves the real device
- a full Bluetooth disconnect/reconnect cycle was run in the app afterwards and succeeded via the Win32 path, with no crash and an empty crash log

Worth stating plainly: the fallback fix was **not** what made that cycle succeed - Win32 worked on its own. The fallback matters for the cases where it does not, which is precisely when connect is unreliable, and it could not have helped before this change.

The crash itself remains unexplained and is not fixed here. This change only makes the next occurrence diagnosable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mAyGLPdG6hLauG7teRbpD
