### PR TITLE
State the copyright position explicitly

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,12 @@
+Copyright (c) 2026 Piers Carrigan. All rights reserved.
+
+This source code is published so that it can be read and reviewed. It is not
+open source, and no licence is granted to use, copy, modify, merge, publish,
+distribute, sublicense or sell this software or any part of it, in source or
+binary form.
+
+Viewing and forking through GitHub's own interface is permitted only to the
+extent that the GitHub Terms of Service require; that does not grant any
+further rights.
+
+For any other use, including commercial use, please get in touch.


### PR DESCRIPTION
Adds a `LICENSE` making the copyright position explicit: **all rights reserved, published for review**.

Publishing with no licence file already means all rights reserved, so this changes nothing legally - but silence reads as an oversight rather than a decision, and this says it plainly.

Chosen over MIT deliberately. MIT is irrevocable for versions already published under it: anyone who received a copy keeps the right to fork, modify and sell that snapshot forever. Staying reserved keeps commercial options open, and a licence can always be added later - it just cannot be taken back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3UACa4k5uwjYLpzGHeQUx