### PR TITLE
Only render icon keys we recognise

### DIFF
--- a/src/icons.py
+++ b/src/icons.py
@@ -53,6 +53,9 @@ _KEYWORD_MAP: list[tuple[list[str], str]] = [
 
 FALLBACK_ICON = "audio"
 
+# Everything get_icon will render: the device icons plus the menu checkmark.
+_RENDERABLE_KEYS = frozenset(ICON_TYPES) | {"checkmark"}
+
 
 def _resources_dir() -> Path:
     """Return path to the resources/ directory, handling frozen builds."""
@@ -98,6 +101,13 @@ class IconManager:
         Returns:
             A tinted QIcon ready for display.
         """
+        # icon_key can originate from icon_overrides in config.json, and it is
+        # joined into a path below, so a value like '../../foo' would read an
+        # SVG from outside resources/. Validate at the sink, which covers every
+        # caller regardless of where the key came from.
+        if icon_key not in _RENDERABLE_KEYS:
+            icon_key = FALLBACK_ICON
+
         cache_key = (icon_key, size)
         if cache_key in self._cache:
             return self._cache[cache_key]


### PR DESCRIPTION
`IconManager.get_icon` joined `icon_key` straight into a path:

```python
svg_path = self._resources / f"{icon_key}.svg"
```

That key can come from `icon_overrides` in `%APPDATA%\audioflip\config.json`, which `Config.load` reads with a bare `data.get("icon_overrides", {})` and never validates. A value containing `../` would therefore load an SVG from outside `resources/`.

Defence in depth rather than an exploitable hole - anyone able to write that config file already has code execution as the user - but it is a one-line invariant worth holding.

Unknown keys now fall back to `FALLBACK_ICON`. Validated at the **sink** rather than on config load, for two reasons: it covers every caller regardless of where the key came from, and reaching `ICON_TYPES` from `config.py` would have pulled PyQt6 into config loading, which is otherwise Qt-free.

Verified: `headphones`, `checkmark` and `audio` still render; `../../../Windows/win` and `nonsense` fall back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3UACa4k5uwjYLpzGHeQUx